### PR TITLE
[Feature] Add docker-compose support to easily launch/test smartBCH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+FROM ubuntu:20.04
+
+MAINTAINER Josh Ellithorpe <quest@mac.com>
+
+ENV DEBIAN_FRONTEND="noninteractive"
+RUN apt-get -y update && apt-get -y upgrade
+RUN apt-get -y install gcc-8 g++-8 gcc g++ libgflags-dev libsnappy-dev zlib1g-dev libbz2-dev liblz4-dev libzstd-dev wget make git
+
+RUN mkdir /build
+WORKDIR /build
+RUN wget https://dl.google.com/go/go1.16.3.linux-amd64.tar.gz
+RUN tar zxvf go1.16.3.linux-amd64.tar.gz
+RUN mv go /usr/local
+RUN mkdir -p /go/bin
+RUN wget https://github.com/facebook/rocksdb/archive/refs/tags/v5.18.4.tar.gz
+RUN tar zxvf v5.18.4.tar.gz
+
+ENV GOROOT=/usr/local/go
+ENV GOPATH=/go
+ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+
+WORKDIR /build/rocksdb-5.18.4
+RUN make CC=gcc-8 CXX=g++-8 shared_lib
+
+ENV ROCKSDB_PATH="/build/rocksdb-5.18.4"
+ENV CGO_CFLAGS="-I/$ROCKSDB_PATH/include"
+ENV CGO_LDFLAGS="-L/$ROCKSDB_PATH -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -llz4 -lzstd"
+ENV LD_LIBRARY_PATH=$ROCKSDB_PATH
+
+RUN mkdir /smart_bch
+WORKDIR /smart_bch
+RUN git clone https://github.com/smartbch/moeingevm.git
+RUN git clone https://github.com/smartbch/smartbch.git
+
+WORKDIR /smart_bch/moeingevm/evmwrap
+RUN make
+
+ENV EVMWRAP=/smart_bch/moeingevm/evmwrap/host_bridge/libevmwrap.so
+
+WORKDIR /smart_bch/smartbch
+RUN go install github.com/smartbch/smartbch/cmd/smartbchd
+
+VOLUME ["/root/.smartbchd"]
+
+ENTRYPOINT ["smartbchd"]
+EXPOSE 8545

--- a/README.md
+++ b/README.md
@@ -7,4 +7,17 @@ You can get more information at [smartbch.org](https://smartbch.org).
 We are actively developing smartBCH and a testnet will launch soon. Before that, you can [download the source code](https://github.com/smartbch/smartbch/releases/tag/v0.1.0) and start [a private single node testnet](https://docs.smartbch.org/smartbch/deverlopers-guide/runsinglenode) to test your DApp.
 
 
+### Docker
 
+To run smartBCH via `docker-compose` you can execute the commands below! Note, the first time you run docker-compose it will take a while, as it will need to build the docker image.
+
+```
+# Generate a set of 10 test keys.
+docker-compose run smartbch gen-test-keys -n 10
+
+# Init the node, include the keys from the last step as a comma separated list.
+docker-compose run smartbch init mynode --chain-id 0x1 --init-balance=10000000000000000000 --test-keys="KEY1,KEY2,KEY3,ETC"
+
+# Start it up, you are all set!
+docker-compose up
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.8'
+
+services:
+  smartbch:
+    build: .
+    command: start
+    ports:
+      - "8545:8545"
+    restart: always
+    volumes:
+      - smartbch_data:/root/.smartbchd
+volumes:
+    smartbch_data:


### PR DESCRIPTION
This PR brings docker/docker-compose support to smartBCH.

To run smartBCH via `docker-compose` you can execute the commands below. Note, the first time you run docker-compose it will take a while, as it will need to build the docker image. If you are impatient I also have a pre-built image at https://hub.docker.com/repository/docker/zquestz/smartbch.

```
# Generate a set of 10 test keys.
docker-compose run smartbch gen-test-keys -n 10

# Init the node, include the keys from the last step as a comma separated list.
docker-compose run smartbch init mynode --chain-id 0x1 --init-balance=10000000000000000000 --test-keys="KEY1,KEY2,KEY3,ETC"

# Start it up, you are all set!
docker-compose up
```