### PR TITLE
Add an optimized version of Dockerfile.mainnet

### DIFF
--- a/Dockerfile.mainnet.optimized
+++ b/Dockerfile.mainnet.optimized
@@ -1,0 +1,81 @@
+FROM ubuntu:20.04
+
+MAINTAINER Josh Ellithorpe <quest@mac.com>
+
+ARG GOLANG_TAR="go1.16.5.linux-amd64.tar.gz"
+ARG PATCH_CGO_TAR="v0.1.1.tar.gz"
+ARG SNAPPY_TAR="1.1.8.tar.gz"
+ARG ROCKSDB_TAR="v5.18.4.tar.gz"
+ARG SMARTBCH_RELEASE_VERSION="v0.3.0"
+ARG SMARTBCH_ARTIFACTS_VERSION="v0.0.3"
+
+ENV DEBIAN_FRONTEND="noninteractive"
+ENV GOROOT=/usr/local/go
+ENV GOPATH=/go
+ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+ENV LD_LIBRARY_PATH=/usr/local/lib
+ENV CGO_CFLAGS="-I/$LD_LIBRARY_PATH/include"
+ENV CGO_LDFLAGS="-L/$LD_LIBRARY_PATH -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -llz4 -lzstd"
+ENV EVMWRAP=/build/libevmwrap.so
+
+RUN set -ex && \
+    # Update file limit
+    sed -i -e '$a* soft nofile 65536\n* hard nofile 65536' /etc/security/limits.conf && \
+    # Install apt based dependencies
+    apt-get -y update && \
+    apt-get -y upgrade && \
+    apt-get -y install cmake gcc-8 g++-8 gcc g++ git libgflags-dev zlib1g-dev libbz2-dev liblz4-dev libzstd-dev make wget && \
+    # Setup build directory
+    mkdir /build && \
+    # Install Go
+    cd /build && \
+    wget https://dl.google.com/go/${GOLANG_TAR} && \
+    tar zxvf ${GOLANG_TAR} -C /usr/local && \
+    mkdir -p /go/bin && \
+    # Patch Go for larger cgo stack size
+    wget https://github.com/smartbch/patch-cgo-for-golang/archive/refs/tags/${PATCH_CGO_TAR} && \
+    tar zxvf ${PATCH_CGO_TAR} -C $GOROOT/src/runtime/cgo/ --strip-components=1 --wildcards "*.c" && \
+    # Build libsnappy
+    cd /build && \
+    wget https://github.com/google/snappy/archive/refs/tags/${SNAPPY_TAR} && \
+    mkdir snappy && tar zxvf ${SNAPPY_TAR} -C snappy --strip-components=1 && \
+    cd snappy && mkdir build && cd build && cmake -DBUILD_SHARED_LIBS=On ../ && make -j4 && make install && \
+    # Build rocksdb
+    cd /build && \
+    wget https://github.com/facebook/rocksdb/archive/refs/tags/${ROCKSDB_TAR} && \
+    mkdir rocksdb && tar zxvf ${ROCKSDB_TAR} -C rocksdb --strip-components=1 && \
+    cd rocksdb && DEBUG_LEVEL=0 make -j4 CC=gcc-8 CXX=g++-8 shared_lib install-shared && \
+    # Remove build artifacts
+    rm -rf /build/* && \
+    # Build libevmwrap.so
+    cd /build && \
+    git clone -b ${SMARTBCH_RELEASE_VERSION} --depth 1 https://github.com/smartbch/moeingevm && \
+    cd moeingevm/evmwrap && make -j4 && \
+    cp host_bridge/libevmwrap.so /build && \
+    rm -rf /build/moeingevm/ && \
+    # Build smartbchd
+    cd /build && \
+    git clone -b ${SMARTBCH_RELEASE_VERSION} --depth 1 https://github.com/smartbch/smartbch && \
+    cd smartbch && go build -tags cppbtree github.com/smartbch/smartbch/cmd/smartbchd && \
+    cp smartbchd /build && \
+    rm -rf /build/smartbch/ && \
+    # Init chain
+    cd /root && \
+    /build/smartbchd init mynode --chain-id 0x2710 && \
+    wget https://github.com/smartbch/artifacts/releases/download/${SMARTBCH_ARTIFACTS_VERSION}/dot.smartbchd.tgz && \
+    tar zxvf dot.smartbchd.tgz -C .smartbchd/ --strip-components=1 && \
+    rm dot.smartbchd.tgz && \
+    # Remove compiler dependencies and clean up cache
+    rm -rf /usr/local/go /go /root/.cache && \
+    apt-get -y remove cmake gcc-8 g++-8 gcc g++ git make wget && \
+    apt-get -y --purge autoremove && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Go back to main workdir.
+WORKDIR /build
+
+VOLUME ["/root/.smartbchd"]
+
+ENTRYPOINT ["./smartbchd"]
+EXPOSE 8545 8546

--- a/Dockerfile.mainnet.optimized
+++ b/Dockerfile.mainnet.optimized
@@ -29,44 +29,44 @@ RUN set -ex && \
     mkdir /build && \
     # Install Go
     cd /build && \
-    wget https://dl.google.com/go/${GOLANG_TAR} && \
-    tar zxvf ${GOLANG_TAR} -C /usr/local && \
-    mkdir -p /go/bin && \
+    wget https://dl.google.com/go/$GOLANG_TAR && \
+    tar zxvf $GOLANG_TAR -C /usr/local && \
+    mkdir -p $GOPATH/bin && \
     # Patch Go for larger cgo stack size
-    wget https://github.com/smartbch/patch-cgo-for-golang/archive/refs/tags/${PATCH_CGO_TAR} && \
-    tar zxvf ${PATCH_CGO_TAR} -C $GOROOT/src/runtime/cgo/ --strip-components=1 --wildcards "*.c" && \
+    wget https://github.com/smartbch/patch-cgo-for-golang/archive/refs/tags/$PATCH_CGO_TAR && \
+    tar zxvf $PATCH_CGO_TAR -C $GOROOT/src/runtime/cgo/ --strip-components=1 --wildcards "*.c" && \
     # Build libsnappy
     cd /build && \
-    wget https://github.com/google/snappy/archive/refs/tags/${SNAPPY_TAR} && \
-    mkdir snappy && tar zxvf ${SNAPPY_TAR} -C snappy --strip-components=1 && \
+    wget https://github.com/google/snappy/archive/refs/tags/$SNAPPY_TAR && \
+    mkdir snappy && tar zxvf $SNAPPY_TAR -C snappy --strip-components=1 && \
     cd snappy && mkdir build && cd build && cmake -DBUILD_SHARED_LIBS=On ../ && make -j4 && make install && \
     # Build rocksdb
     cd /build && \
-    wget https://github.com/facebook/rocksdb/archive/refs/tags/${ROCKSDB_TAR} && \
-    mkdir rocksdb && tar zxvf ${ROCKSDB_TAR} -C rocksdb --strip-components=1 && \
+    wget https://github.com/facebook/rocksdb/archive/refs/tags/$ROCKSDB_TAR && \
+    mkdir rocksdb && tar zxvf $ROCKSDB_TAR -C rocksdb --strip-components=1 && \
     cd rocksdb && DEBUG_LEVEL=0 make -j4 CC=gcc-8 CXX=g++-8 shared_lib install-shared && \
     # Remove build artifacts
     rm -rf /build/* && \
     # Build libevmwrap.so
     cd /build && \
-    git clone -b ${SMARTBCH_RELEASE_VERSION} --depth 1 https://github.com/smartbch/moeingevm && \
+    git clone -b $SMARTBCH_RELEASE_VERSION --depth 1 https://github.com/smartbch/moeingevm && \
     cd moeingevm/evmwrap && make -j4 && \
     cp host_bridge/libevmwrap.so /build && \
     rm -rf /build/moeingevm/ && \
     # Build smartbchd
     cd /build && \
-    git clone -b ${SMARTBCH_RELEASE_VERSION} --depth 1 https://github.com/smartbch/smartbch && \
+    git clone -b $SMARTBCH_RELEASE_VERSION --depth 1 https://github.com/smartbch/smartbch && \
     cd smartbch && go build -tags cppbtree github.com/smartbch/smartbch/cmd/smartbchd && \
     cp smartbchd /build && \
     rm -rf /build/smartbch/ && \
     # Init chain
     cd /root && \
     /build/smartbchd init mynode --chain-id 0x2710 && \
-    wget https://github.com/smartbch/artifacts/releases/download/${SMARTBCH_ARTIFACTS_VERSION}/dot.smartbchd.tgz && \
+    wget https://github.com/smartbch/artifacts/releases/download/$SMARTBCH_ARTIFACTS_VERSION/dot.smartbchd.tgz && \
     tar zxvf dot.smartbchd.tgz -C .smartbchd/ --strip-components=1 && \
     rm dot.smartbchd.tgz && \
     # Remove compiler dependencies and clean up cache
-    rm -rf /usr/local/go /go /root/.cache && \
+    rm -rf $GOROOT $GOPATH /root/.cache && \
     apt-get -y remove cmake gcc-8 g++-8 gcc g++ git make wget && \
     apt-get -y --purge autoremove && \
     apt-get clean && \

--- a/Dockerfile.mainnet.optimized
+++ b/Dockerfile.mainnet.optimized
@@ -38,8 +38,8 @@ RUN set -ex && \
     # Build libsnappy
     cd /build && \
     wget https://github.com/google/snappy/archive/refs/tags/$SNAPPY_TAR && \
-    mkdir snappy && tar zxvf $SNAPPY_TAR -C snappy --strip-components=1 && \
-    cd snappy && mkdir build && cd build && cmake -DBUILD_SHARED_LIBS=On ../ && make -j4 && make install && \
+    mkdir -p snappy/build && tar zxvf $SNAPPY_TAR -C snappy --strip-components=1 && \
+    cd snappy/build && cmake -DBUILD_SHARED_LIBS=On ../ && make -j4 install && \
     # Build rocksdb
     cd /build && \
     wget https://github.com/facebook/rocksdb/archive/refs/tags/$ROCKSDB_TAR && \


### PR DESCRIPTION
1. Reduce disk usage: image size reduced by ~9x (Dockerfile.mainnet 2.82G ->  Dockerfile.mainnet.optimized 323MB).
2. Speed up compiling: append every "make" command with "-j4". 
3. Make tar extraction commands more concise.
4. Parameterize dependency filename or version. Easier to modify for future releases. 