### PR TITLE
Changed hardcoded ports to parameters

### DIFF
--- a/cmd/smartbchd/start.go
+++ b/cmd/smartbchd/start.go
@@ -29,8 +29,10 @@ import (
 
 const (
 	flagRpcAddr              = "http.addr"
+	flagRpcAddrSecure        = "https.addr"
 	flagCorsDomain           = "http.corsdomain"
 	flagWsAddr               = "ws.addr"
+	flagWsAddrSecure         = "wss.addr"
 	flagMaxOpenConnections   = "rpc.max-open-connections"
 	flagReadTimeout          = "rpc.read-timeout"
 	flagWriteTimeout         = "rpc.write-timeout"
@@ -64,7 +66,9 @@ func StartCmd(ctx *Context, appCreator AppCreator) *cobra.Command {
 	cmd.Flags().Int64(flagRetainBlocks, -1, "Latest blocks this node retain, default retain all blocks")
 	cmd.Flags().Int64(flagGenesisMainnetHeight, 0, "genesis bch mainnet height for validator voting watched")
 	cmd.Flags().String(flagRpcAddr, "tcp://:8545", "HTTP-RPC server listening address")
+	cmd.Flags().String(flagRpcAddrSecure, "tcp://:9545", "HTTPS-RPC server listening address")
 	cmd.Flags().String(flagWsAddr, "tcp://:8546", "WS-RPC server listening address")
+	cmd.Flags().String(flagWsAddrSecure, "tcp://:9546", "WSS-RPC server listening address")
 	cmd.Flags().String(flagCorsDomain, "*", "Comma separated list of domains from which to accept cross origin requests (browser enforced)")
 	cmd.Flags().Uint(flagMaxOpenConnections, uint(defaultRpcCfg.MaxOpenConnections), "max open connections of RPC server")
 	cmd.Flags().Uint(flagReadTimeout, 10, "read timeout (in seconds) of RPC server")
@@ -133,11 +137,13 @@ func startInProcess(ctx *Context, appCreator AppCreator) (*node.Node, error) {
 	rpcBackend := api.NewBackend(tmNode, appImpl)
 	rpcAddr := viper.GetString(flagRpcAddr)
 	wsAddr := viper.GetString(flagWsAddr)
+	rpcAddrSecure := viper.GetString(flagRpcAddrSecure)
+	wsAddrSecure := viper.GetString(flagWsAddrSecure)
 	corsDomain := viper.GetString(flagCorsDomain)
 	unlockedKeys := viper.GetString(flagUnlock)
 	certfileDir := filepath.Join(nodeCfg.RootDir, "nodeCfg/cert.pem")
 	keyfileDir := filepath.Join(nodeCfg.RootDir, "nodeCfg/key.pem")
-	rpcServer := rpc.NewServer(rpcAddr, wsAddr, corsDomain, certfileDir, keyfileDir,
+	rpcServer := rpc.NewServer(rpcAddr, wsAddr, rpcAddrSecure, wsAddrSecure, corsDomain, certfileDir, keyfileDir,
 		serverCfg, rpcBackend, ctx.Logger, strings.Split(unlockedKeys, ","))
 
 	if err := rpcServer.Start(); err != nil {

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -45,7 +45,7 @@ type Server struct {
 	unlockedKeys []string
 }
 
-func NewServer(rpcAddr, wsAddr, corsDomain, certFile, keyFile string,
+func NewServer(rpcAddr, wsAddr, rpcAddrSecure, wsAddrSecure, corsDomain, certFile, keyFile string,
 	serverCfg *tmrpcserver.Config, backend api.BackendService,
 	logger tmlog.Logger, unlockedKeys []string) tmservice.Service {
 
@@ -59,8 +59,8 @@ func NewServer(rpcAddr, wsAddr, corsDomain, certFile, keyFile string,
 		backend:      backend,
 		logger:       logger,
 		unlockedKeys: unlockedKeys,
-		rpcHttpsAddr: "tcp://:9545",
-		wssAddr:      "tcp://:9546",
+		rpcHttpsAddr: rpcAddrSecure, //"tcp://:9545",
+		wssAddr:      wsAddrSecure,  //"tcp://:9546",
 	}
 	return tmservice.NewBaseService(logger, "", impl)
 }


### PR DESCRIPTION
The HTTPS RPC port and WSS port were hardcoded in rpc/server.go. This causes an issue if these ports are already in use (ie, by another application or when running a mainnet and amber testnet node on the same machine). This is fixed by making these values parameterized.