### PR TITLE
Dockerfile: parameterize gcc version

### DIFF
--- a/Dockerfile.mainnet
+++ b/Dockerfile.mainnet
@@ -17,7 +17,7 @@ RUN sed -i -e '$a* soft nofile 65536\n* hard nofile 65536' /etc/security/limits.
 # Install apt based dependencies
 ENV DEBIAN_FRONTEND="noninteractive"
 RUN apt-get -y update && apt-get -y upgrade
-RUN apt-get -y install cmake gcc-8 g++-8 gcc g++ git libgflags-dev make vim wget
+RUN apt-get -y install cmake g++ gcc git libgflags-dev make vim wget
 
 # Setup build directory
 RUN mkdir /build
@@ -42,12 +42,15 @@ RUN cd patch-cgo-for-golang-${PATCH_CGO_VERSION} && cp *.c $GOROOT/src/runtime/c
 # Build libsnappy
 RUN wget https://github.com/google/snappy/archive/refs/tags/${SNAPPY_VERSION}.tar.gz
 RUN tar zxvf ${SNAPPY_VERSION}.tar.gz
-RUN cd snappy-${SNAPPY_VERSION} && mkdir build && cd build && cmake ../ && make && make install
+RUN cd snappy-${SNAPPY_VERSION} && mkdir build && cd build && \
+    CXX=g++ cmake ../ && make CC=gcc CXX=g++ && make install
 
 # Build rocksdb
 RUN wget https://github.com/facebook/rocksdb/archive/refs/tags/v${ROCKSDB_VERSION}.tar.gz
 RUN tar zxvf v${ROCKSDB_VERSION}.tar.gz
-RUN cd rocksdb-${ROCKSDB_VERSION} && make CC=gcc-8 CXX=g++-8 static_lib
+RUN cd rocksdb-${ROCKSDB_VERSION} && \
+    wget -O - https://raw.githubusercontent.com/smartbch/artifacts/main/patches/rocksdb.gcc11.patch | git apply -v && \
+    CXXFLAGS=-Wno-range-loop-construct make -j4 CC=gcc CXX=g++ static_lib
 
 # Create smartbch directory
 RUN mkdir /smart_bch

--- a/Dockerfile.optimized
+++ b/Dockerfile.optimized
@@ -11,6 +11,8 @@ ARG PATCH_CGO_VERSION="0.1.2"
 ARG ROCKSDB_VERSION="5.18.4"
 ARG SNAPPY_VERSION="1.1.8"
 
+ARG GCC_VERSION="9"
+ENV GV=${GCC_VERSION}
 ARG TARGETARCH
 ENV TARGETARCH=${TARGETARCH:-amd64}
 ARG SMARTBCH_BUILD_TAGS="cppbtree"
@@ -18,7 +20,8 @@ ARG CHAIN_ID="0x2710"
 
 # Install apt based dependencies
 RUN apt-get -y update && apt-get -y upgrade
-RUN DEBIAN_FRONTEND="noninteractive" apt-get -y install cmake gcc-8 g++-8 gcc g++ git libgflags-dev make wget
+RUN apt-get install -y software-properties-common && add-apt-repository -y ppa:ubuntu-toolchain-r/test
+RUN apt-get -y install cmake gcc-${GV} g++-${GV} gcc g++ git libgflags-dev make wget
 
 # Setup build directory
 RUN mkdir /build
@@ -40,12 +43,21 @@ RUN go version
 # Build libsnappy
 RUN wget https://github.com/google/snappy/archive/refs/tags/${SNAPPY_VERSION}.tar.gz
 RUN mkdir -p snappy/build && tar zxvf ${SNAPPY_VERSION}.tar.gz -C snappy --strip-components=1
-RUN cd snappy/build && cmake -DSNAPPY_BUILD_TESTS=0 -DCMAKE_BUILD_TYPE=Release ../ && make -j4 install
+RUN cd snappy/build && \
+    CXX=g++-${GV} cmake -DSNAPPY_BUILD_TESTS=0 -DCMAKE_BUILD_TYPE=Release ../ && \
+    make -j4 CC=gcc-${GV} CXX=g++-${GV} install
 
 # Build rocksdb
 RUN wget https://github.com/facebook/rocksdb/archive/refs/tags/v${ROCKSDB_VERSION}.tar.gz
 RUN mkdir rocksdb && tar zxvf v${ROCKSDB_VERSION}.tar.gz -C rocksdb --strip-components=1
-RUN cd rocksdb && PORTABLE=1 make -j4 CC=gcc-8 CXX=g++-8 static_lib && strip --strip-unneeded librocksdb.a
+RUN cd rocksdb && \
+    wget -O - https://raw.githubusercontent.com/smartbch/artifacts/main/patches/rocksdb.gcc11.patch | git apply -v && \
+    LDFLAGS="-static" CXXFLAGS=-Wno-range-loop-construct PORTABLE=1 make -j4 CC=gcc-${GV} CXX=g++-${GV} static_lib && \
+    strip --strip-unneeded librocksdb.a
+
+# Ugly hack: force compiling libevmwrap and smartbchd with gcc-${GV} and g++-${GV}
+RUN ln -s /usr/bin/gcc-${GV} /usr/local/bin/gcc
+RUN ln -s /usr/bin/g++-${GV} /usr/local/bin/g++
 
 # Build libevmwrap
 RUN git clone -b ${MOEINGEVM_VERSION} --depth 1 https://github.com/smartbch/moeingevm
@@ -54,7 +66,7 @@ RUN cd moeingevm/evmwrap && make -j4
 # Build smartbchd
 ENV ROCKSDB_PATH="/build/rocksdb"
 ENV CGO_CFLAGS="-I$ROCKSDB_PATH/include"
-ENV CGO_LDFLAGS="-L$ROCKSDB_PATH -L/build/moeingevm/evmwrap/host_bridge/ -l:librocksdb.a -lstdc++ -lm -lsnappy"
+ENV CGO_LDFLAGS="-static -L$ROCKSDB_PATH -L/build/moeingevm/evmwrap/host_bridge/ -l:librocksdb.a -lstdc++ -lm -lsnappy"
 RUN git clone -b ${SMARTBCH_VERSION} --depth 1 https://github.com/smartbch/smartbch
 RUN cd smartbch && go build -tags ${SMARTBCH_BUILD_TAGS} github.com/smartbch/smartbch/cmd/smartbchd
 


### PR DESCRIPTION
Preliminary testing result: docker containers running on images built with GCC_VERSION=9, 10 or 11 are all properly starting up and syncing blocks.

Note:
1. Ugly hack of forcing compiling libevmwrap and smartbchd with specified gcc and g++ version
```
RUN ln -s /usr/bin/gcc-${GV} /usr/local/bin/gcc
RUN ln -s /usr/bin/g++-${GV} /usr/local/bin/g++
```
2. Make smartbchd static linking against everything to avoid runtime errors compiled with GCC_VERSION=11, probably due to missing gcc-11 essential libraries on default Ubuntu 20.04 installation

GCC_VERSION=11 and without ''-static"
```
~# ldd ./smartbchd
./smartbchd: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by ./smartbchd)
./smartbchd: /lib/x86_64-linux-gnu/libstdc++.so.6: version `CXXABI_1.3.13' not found (required by ./smartbchd)
        linux-vdso.so.1 (0x00007fff812cf000)
        libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f12b077b000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f12b062c000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f12b0609000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f12b0417000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f12b0961000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f12b03fc000)
```
GCC_VERSION=11 and with ''-static"
```
~# ldd ./smartbchd
        not a dynamic executable
```