### PR TITLE
Dockerfile: change base os image, remove ulimit setting and other minor fixes

### DIFF
--- a/Dockerfile.mainnet
+++ b/Dockerfile.mainnet
@@ -11,9 +11,6 @@ ARG PATCH_CGO_VERSION="0.1.2"
 ARG ROCKSDB_VERSION="5.18.4"
 ARG SNAPPY_VERSION="1.1.8"
 
-# Update file limit
-RUN sed -i -e '$a* soft nofile 65536\n* hard nofile 65536' /etc/security/limits.conf
-
 # Install apt based dependencies
 ENV DEBIAN_FRONTEND="noninteractive"
 RUN apt-get -y update && apt-get -y upgrade

--- a/Dockerfile.optimized
+++ b/Dockerfile.optimized
@@ -23,6 +23,9 @@ RUN apt-get -y update && apt-get -y upgrade
 RUN apt-get install -y software-properties-common && add-apt-repository -y ppa:ubuntu-toolchain-r/test
 RUN apt-get -y install cmake gcc-${GV} g++-${GV} gcc g++ git libgflags-dev make wget
 
+# Make wget produce less visual noise in output
+RUN echo "quiet=on\nshow-progress=on\nprogress=bar:force:noscroll" > ~/.wgetrc
+
 # Setup build directory
 RUN mkdir /build
 WORKDIR /build
@@ -31,28 +34,28 @@ WORKDIR /build
 ENV GOROOT=/usr/local/go
 ENV GOPATH=/go
 ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
-RUN wget https://dl.google.com/go/go${GOLANG_VERSION}.linux-${TARGETARCH}.tar.gz
-RUN tar zxvf go${GOLANG_VERSION}.linux-${TARGETARCH}.tar.gz -C /usr/local
+RUN wget -O go.tgz https://dl.google.com/go/go${GOLANG_VERSION}.linux-${TARGETARCH}.tar.gz
+RUN tar -zxf go.tgz -C /usr/local
 RUN mkdir -p $GOPATH/bin
 
 # Patch Go for larger cgo stack size
-RUN wget https://github.com/smartbch/patch-cgo-for-golang/archive/refs/tags/v${PATCH_CGO_VERSION}.tar.gz
-RUN tar zxvf v${PATCH_CGO_VERSION}.tar.gz -C $GOROOT/src/runtime/cgo/ --strip-components=1 --wildcards "*.c"
+RUN wget -O cgo.tgz https://github.com/smartbch/patch-cgo-for-golang/archive/refs/tags/v${PATCH_CGO_VERSION}.tar.gz
+RUN tar -zxf cgo.tgz -C $GOROOT/src/runtime/cgo/ --strip-components=1 --wildcards "*.c"
 RUN go version
 
 # Build libsnappy
-RUN wget https://github.com/google/snappy/archive/refs/tags/${SNAPPY_VERSION}.tar.gz
-RUN mkdir -p snappy/build && tar zxvf ${SNAPPY_VERSION}.tar.gz -C snappy --strip-components=1
+RUN wget -O snappy.tgz https://github.com/google/snappy/archive/refs/tags/${SNAPPY_VERSION}.tar.gz
+RUN mkdir -p snappy/build && tar -zxf snappy.tgz -C snappy --strip-components=1
 RUN cd snappy/build && \
     CXX=g++-${GV} cmake -DSNAPPY_BUILD_TESTS=0 -DCMAKE_BUILD_TYPE=Release ../ && \
     make -j4 CC=gcc-${GV} CXX=g++-${GV} install
 
 # Build rocksdb
-RUN wget https://github.com/facebook/rocksdb/archive/refs/tags/v${ROCKSDB_VERSION}.tar.gz
-RUN mkdir rocksdb && tar zxvf v${ROCKSDB_VERSION}.tar.gz -C rocksdb --strip-components=1
+RUN wget -O rocksdb.tgz https://github.com/facebook/rocksdb/archive/refs/tags/v${ROCKSDB_VERSION}.tar.gz
+RUN mkdir rocksdb && tar -zxf rocksdb.tgz -C rocksdb --strip-components=1
 RUN cd rocksdb && \
     wget -O - https://raw.githubusercontent.com/smartbch/artifacts/main/patches/rocksdb.gcc11.patch | git apply -v && \
-    LDFLAGS="-static" CXXFLAGS=-Wno-range-loop-construct PORTABLE=1 make -j4 CC=gcc-${GV} CXX=g++-${GV} static_lib && \
+    CXXFLAGS=-Wno-range-loop-construct PORTABLE=1 make -j4 CC=gcc-${GV} CXX=g++-${GV} static_lib && \
     strip --strip-unneeded librocksdb.a
 
 # Ugly hack: force compiling libevmwrap and smartbchd with gcc-${GV} and g++-${GV}
@@ -74,23 +77,19 @@ RUN cd smartbch && go build -tags ${SMARTBCH_BUILD_TAGS} github.com/smartbch/sma
 WORKDIR /root/
 RUN /build/smartbch/smartbchd init mynode --chain-id ${CHAIN_ID}
 RUN wget https://github.com/smartbch/artifacts/releases/download/${CONFIG_VERSION}/dot.smartbchd.tgz
-RUN tar zxvf dot.smartbchd.tgz -C .smartbchd/ --strip-components=1
+RUN tar -zxf dot.smartbchd.tgz -C .smartbchd/ --strip-components=1
 
-FROM ubuntu:20.04
+FROM alpine:latest
 
-RUN apt-get -y update && apt-get -y upgrade && apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-# Update file limit
-RUN sed -i -e '$a* soft nofile 65536\n* hard nofile 65536' /etc/security/limits.conf
+RUN apk add --no-cache ca-certificates
 
 # Copy smartbchd binary and config files from previous stage
-COPY --from=builder /build/smartbch/smartbchd /root/
+COPY --from=builder /build/smartbch/smartbchd /usr/local/bin/
 COPY --from=builder /root/.smartbchd /root/.smartbchd
 
 WORKDIR /root/
 
 VOLUME ["/root/.smartbchd"]
 
-ENTRYPOINT ["./smartbchd"]
+ENTRYPOINT ["smartbchd"]
 EXPOSE 8545 8546


### PR DESCRIPTION
1. Reduce image size from ~140MB to ~50MB by changing base OS image from `ubuntu:20.04` to `alpine:latest` 
   Inspired by
   https://github.com/ethereum/go-ethereum/blob/f94e23ca66eef8fdac2473ce99ca6ad57324aaa2/Dockerfile#L15-L18 

2. Remove file limit setting in `Dockerfile`
 https://github.com/smartbch/smartbch/blob/a857e5fa397d377074b2ac6adc61679b317cbfae/Dockerfile.optimized#L84-L85
 Unfortunately this way of setting ulimit for docker containers is not effective at all.
 a) Ubuntu docker host:
```
❯ sudo docker run -it --entrypoint /bin/bash smartbch/smartbchd:v0.4.4
root@0c8830ea36b5:~# ulimit -Hn
1048576
root@0c8830ea36b5:~# ulimit -Sn
1048576
```
 b) WSL2 docker host:
```
❯ sudo docker run -it --entrypoint /bin/bash smartbch/smartbchd:v0.4.4
root@e0a4118882c1:~# ulimit -Hn
4096
root@e0a4118882c1:~# ulimit -Sn
1024
```  
  To fix this: one safe way(as in running docker container without extra privileges(--privileged))  [(related doc)](https://docs.docker.com/engine/reference/commandline/run/#set-ulimits-in-container---ulimit) is like this: docker run -it **--ulimit nofile=65535:65535** --entrypoint /bin/bash smartbch/smartbchd:v0.4.4
```
❯ sudo docker run -it --ulimit nofile=65535:65535 --entrypoint /bin/bash smartbch/smartbchd:v0.4.4
root@af68b9de589f:~# ulimit -Hn
65535
root@af68b9de589f:~# ulimit -Sn
65535 
```
   And related PR for smartbch/docs is put up here : https://github.com/smartbch/docs/pull/65

3. Make archive downloading and extraction non-verbose to reduce visual noise in output. Also explicitly naming downloaded archives to improve code clarity
4. Remove extraneous LDFLAGS="-static" on compiling rocksdb